### PR TITLE
Allow apm to be configured from environment variables.

### DIFF
--- a/lib/ibm_apm_restclient/lib/plugins/BIPlugin.js
+++ b/lib/ibm_apm_restclient/lib/plugins/BIPlugin.js
@@ -429,8 +429,8 @@ function initFromEnv() {
         if (process.env.IBM_APM_KEYFILE) {
             try {
                 let buff = fs.readFileSync(__dirname + '/../../etc/' + global_obj.APM_KEYFILE);
-                apmconns[global_obj.APM_BM_GATEWAY_URL].pfx = buff;
-                pfx =
+                pfx = buff;
+                passphrase =
                     (new Buffer(process.env.IBM_APM_KEYFILE_PASSWORD, 'base64')).toString();
                 got_security = true;
             } catch (error) {

--- a/lib/ibm_apm_restclient/lib/plugins/BIPlugin.js
+++ b/lib/ibm_apm_restclient/lib/plugins/BIPlugin.js
@@ -428,7 +428,7 @@ function initFromEnv() {
 
         if (process.env.IBM_APM_KEYFILE) {
             try {
-                let buff = fs.readFileSync(__dirname + '/../../etc/' + global_obj.APM_KEYFILE);
+                let buff = fs.readFileSync(global_obj.APM_KEYFILE);
                 pfx = buff;
                 passphrase =
                     (new Buffer(process.env.IBM_APM_KEYFILE_PASSWORD, 'base64')).toString();


### PR DESCRIPTION
I have tested locally against our apm server and this is working.

I removed the `__dirname` to allow for the key file to be anywhere on the system. and changed the code to store in the variables to be read on line 447